### PR TITLE
Prevent logging going out to Chrome logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 </head>
 <body>
   <script>
+  // Needed to prevent logging out to Chrome
+  console.log = require('console').log
   var ipc = require('ipc')
   var path = require('path')
   ipc.on('args', function (args) {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
   var ipc = require('ipc')
   var path = require('path')
   ipc.on('args', function (args) {
-    var app = require(path.join(process.cwd(), args[2]))
+    var app
+    if (path.isAbsolute(args[2])) {
+      app = require(args[2])
+    } else {
+      app = require(path.join(process.cwd(), args[2]))
+    }
     if (typeof app === 'function') app(args.slice(2))
   })
   </script>

--- a/test.js
+++ b/test.js
@@ -10,8 +10,7 @@ if (process.versions['electron']) {
   test('can spawn electron through an API', function (t) {
     t.plan(1)
     var electron = electronSpawn('test.js')
-    // TODO: This comes in on stderr but it really shouldnt
-    electron.stderr.on('data', function (data) {
+    electron.stdout.on('data', function (data) {
       data = data.toString()
       if (data.indexOf('test success') !== -1) {
         t.ok(data.indexOf('test success: test.js') !== -1, 'found the text we had our electron script output')


### PR DESCRIPTION
This will prevent logging from heading out to Chrome and allows us to read it in a sane way:

```js
// script.js
console.log('TAP version 13')
```

```js
var electron = electronSpawn('script.js')
electron.stdout.on('data', function (data) {
  console.log(data.toString())
})
```

Outputting just the `console.log`:

```shell
TAP version 13
```

Instead of the original mess:

```shell
[39995:0720/165809:INFO:CONSOLE(26)] "TAP version 13", source: /Users/Kyle/Documents/www/testron/node_modules/tape/lib/default_stream.js (26)
```