### PR TITLE
redirect uncaught errors to terminal (stderr) with stack trace

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,16 @@
 </head>
 <body>
   <script>
-  // Needed to prevent logging out to Chrome
+  // redirect log to stdout
   console.log = require('console').log
+
+  // redirect errors to stderr
+  window.addEventListener('error', function (e) {
+    e.preventDefault()
+    require('console').error(e.error.stack || 'Uncaught ' + e.error)
+    require('remote').require('app').quit()
+  })
+  
   var ipc = require('ipc')
   var path = require('path')
   ipc.on('args', function (args) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   window.addEventListener('error', function (e) {
     e.preventDefault()
     require('console').error(e.error.stack || 'Uncaught ' + e.error)
-    require('remote').require('app').quit()
   })
   
   var ipc = require('ipc')


### PR DESCRIPTION
Currently script errors are tricky to debug because there is no stack trace.

This PR hooks `"error"` on `window` and prints the stack trace to `stderr`.

**It also calls `app.quit()`.** Not sure if this is a good idea or not, but it does make the behavior a lot more nodey.