### PR TITLE
Fix for latest electron api.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var app = require('app')
 var BrowserWindow = require('browser-window')
 app.on('ready', function () {
   win = new BrowserWindow({show: false})
-  win.loadUrl('file://' + path.join(__dirname, 'index.html'))  
+  win.loadURL('file://' + path.join(__dirname, 'index.html'))  
   win.webContents.on('did-finish-load', function() {
     win.webContents.send('args', process.argv)
   })


### PR DESCRIPTION
The `loadUrl` capitalization stopped working in v0.36.0 