### PR TITLE
process.stdin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,27 @@
 var path = require('path')
 var app = require('app')
 var BrowserWindow = require('browser-window')
+var ipc = require('electron').ipcMain
+
 app.on('ready', function () {
   win = new BrowserWindow({show: false})
   win.loadURL('file://' + path.join(__dirname, 'index.html'))
   win.webContents.on('did-finish-load', function() {
     win.webContents.send('args', process.argv)
   })
+  var reading = false
+  ipc.on('stdin.read', onread)
+  process.stdin.on('readable', function () {
+    if (reading) onread()
+  })
+  process.stdin.on('end', function () {
+    win.webContents.send('stdin.data', null)
+  })
+  function onread () {
+    var buf = process.stdin.read()
+    reading = false
+    if (buf) win.webContents.send('stdin.data', buf)
+    else reading = true
+  }
 })
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
     }
     if (typeof app === 'function') app(args.slice(2))
   })
+  process.stdin._read = function (n) {
+    ipc.send('stdin.read', n)
+  }
+  ipc.on('stdin.data', function (buf) {
+    process.stdin.push(buf)
+  })
   </script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,19 @@ $ electron-spawn hello.js beep boop
 # outputs: ['beep', 'boop']
 ```
 
+`process.stdin` works too:
+
+``` js
+process.stdin.on('data', function (buf) {
+  console.log('buf=', buf)
+})
+```
+
+```
+$ echo beep boop | electron-spawn stdin.js
+buf= <Buffer 62 65 65 70 20 62 6f 6f 70 0a>
+```
+
 ## api
 
 ### `var spawn = require('electron-spawn')`


### PR DESCRIPTION
This patch adds support for `process.stdin`:

``` js
process.stdin.on('data', function (buf) {
  console.log('buf=', buf)
})
```

```
$ echo beep boop | electron-spawn stdin.js
buf= <Buffer 62 65 65 70 20 62 6f 6f 70 0a>
```