### PR TITLE
Update for Electron 1.0

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,18 +1,16 @@
 #!/usr/bin/env electron
 
+var electron = require('electron')
 var path = require('path')
-var app = require('app')
-var BrowserWindow = require('browser-window')
-var ipc = require('electron').ipcMain
 
-app.on('ready', function () {
-  win = new BrowserWindow({show: false})
+electron.app.on('ready', function () {
+  var win = new electron.BrowserWindow({show: false})
   win.loadURL('file://' + path.join(__dirname, 'index.html'))
-  win.webContents.on('did-finish-load', function() {
+  win.webContents.on('did-finish-load', function () {
     win.webContents.send('args', process.argv)
   })
   var reading = false
-  ipc.on('stdin.read', onread)
+  electron.ipcMain.on('stdin.read', onread)
   process.stdin.on('readable', function () {
     if (reading) onread()
   })

--- a/index.html
+++ b/index.html
@@ -4,19 +4,20 @@
 </head>
 <body>
   <script>
+  var electron = require('electron')
   // redirect log to stdout
-  console.log = require('console').log
-  process.exit = require('remote').require('app').quit
+  console.log = electron.remote.getGlobal('console').log
+  process.exit = electron.remote.app.quit
 
   // redirect errors to stderr
   window.addEventListener('error', function (e) {
     e.preventDefault()
-    require('console').error(e.error.stack || 'Uncaught ' + e.error)
+    console.error(e.error.stack || 'Uncaught ' + e.error)
   })
-  
-  var ipc = require('ipc')
+
+  var ipc = electron.ipcRenderer
   var path = require('path')
-  ipc.on('args', function (args) {
+  ipc.on('args', function (event, args) {
     process.argv = args.slice(1)
     var app
     if (path.isAbsolute(args[2])) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "electron-prebuilt": "^0.30.0",
+    "electron-prebuilt": "^1.0.1",
     "npm-execspawn": "^1.2.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -70,12 +70,12 @@ electron.stdout.on('data', function (data) {
 limitations:
 
 - cannot automatically yet exit your program like how node does when you have no more activity on the event loop  
-  But in your script you can call `require('remote').require('app').quit()` to quit when it's done:
+  But in your script you can call `require('electron').remote.app.quit()` to quit when it's done:
 ```js
 module.exports = function (args) {
   var img = new Image()
   img.onload = function () {
-    require('remote').require('app').quit()
+    require('electron').remote.app.quit()
   }
   img.src = 'http://example.com/cat.gif'
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 if (process.versions['electron']) {
   module.exports = function (scripts) {
     console.log('test success: ' + scripts.join(','))
-    require('remote').require('app').quit()
+    require('electron').remote.app.quit()
   }
 } else {
   var test = require('tape')


### PR DESCRIPTION
When running `npm test`, the run fails because of API differences between electron-spawn and electron-prebuilt@^0.30.0.

132337576405b48b3bce2355ed89cee88e9b6c7d makes this update necessary since a local install will also create an electron install that the user does not control.