### PR TITLE
allowing the option to specify a custom html file to load into the de…

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,9 +5,19 @@ var app = require('app')
 var BrowserWindow = require('browser-window')
 var ipc = require('electron').ipcMain
 
+var getStartingHtmlFilePath = (filename) => {
+    if (filename) {
+        return `../../${filename}`;
+    }
+
+    return 'index.html';
+};
+
+var startingHtmlFilePath = getStartingHtmlFilePath(process.argv[3]);
+
 app.on('ready', function () {
   win = new BrowserWindow({show: false})
-  win.loadURL('file://' + path.join(__dirname, 'index.html'))
+  win.loadURL('file://' + path.join(__dirname, `${startingHtmlFilePath}`))
   win.webContents.on('did-finish-load', function() {
     win.webContents.send('args', process.argv)
   })
@@ -26,4 +36,3 @@ app.on('ready', function () {
     else reading = true
   }
 })
-

--- a/spawn-init.js
+++ b/spawn-init.js
@@ -1,0 +1,28 @@
+// redirect log to stdout
+console.log = require('console').log
+process.exit = require('remote').require('app').quit
+
+// redirect errors to stderr
+window.addEventListener('error', function (e) {
+  e.preventDefault()
+  require('console').error(e.error.stack || 'Uncaught ' + e.error)
+})
+
+var ipc = require('ipc')
+var path = require('path')
+ipc.on('args', function (args) {
+  process.argv = args.slice(1)
+  var app
+  if (path.isAbsolute(args[2])) {
+    app = require(args[2])
+  } else {
+    app = require(path.join(process.cwd(), args[2]))
+  }
+  if (typeof app === 'function') app(args.slice(2))
+})
+process.stdin._read = function (n) {
+  ipc.send('stdin.read', n)
+}
+ipc.on('stdin.data', function (buf) {
+  process.stdin.push(buf)
+})


### PR DESCRIPTION
…fault headless window

What I really want to be able to do is specify an html file to load instead of the default html file. I want the headless electron app to run whatever html file I specify, render the html and do everything like it normally would, just headless. My pull request is probably rudimentary, but maybe it's a good start.