### PR TITLE
Fix a bug in redirecting error to stderr

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   var electron = require('electron')
   // redirect log to stdout
   console.log = electron.remote.getGlobal('console').log
+  console.error = electron.remote.getGlobal('console').error
   process.exit = electron.remote.app.quit
 
   // redirect errors to stderr


### PR DESCRIPTION
Fix #23

Also redirects error log from `console.error()` to stderr.
