### PR TITLE
Change dependency to electron package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-spawn",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "easy way to run code inside of a headless electron window from the CLI",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "electron-prebuilt": "^1.0.1",
+    "electron": "^1.3.1",
     "npm-execspawn": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As stated in issue #25, you shoud consider updating your dependency to electron-prebuilt (now electron) before it is deprecated.

According to semver I propose to increment the patch version since it doesn't introduce any feature, or any additional code to make it work, but pushes the dependency to the 1.3.1 version of electron.

Source from electron-prebuilt's readme : 

> Note As of version 1.3.1, this package is published to npm under two names: electron and electron-prebuilt. You can currently use either name, but electron is recommended, as the electron-prebuilt name is deprecated, and will only be published until the end of 2016.
